### PR TITLE
Improving usability of local docker images.

### DIFF
--- a/cmd/ksync/ksync.go
+++ b/cmd/ksync/ksync.go
@@ -68,6 +68,18 @@ func init() {
 
 		log.Fatal(err)
 	}
+
+	// TODO: can this be hidden?
+	flags.String(
+		"local-image",
+		"gcr.io/elated-embassy-152022/ksync/ksync:canary",
+		// TODO: this help text could be way better
+		"the image to use for running things locally.")
+	if err := cli.BindFlag(
+		viper.GetViper(), flags.Lookup("local-image"), "ksync"); err != nil {
+
+		log.Fatal(err)
+	}
 }
 
 // TODO: dependencies should verify that they're usable (and return errors otherwise).
@@ -76,6 +88,8 @@ func initPersistent(cmd *cobra.Command, args []string) {
 
 	initKubeClient()
 	initDockerClient()
+
+	ksync.SetImage(viper.GetString("local-image"))
 }
 
 func initKubeClient() {

--- a/pkg/docker/image.go
+++ b/pkg/docker/image.go
@@ -1,0 +1,37 @@
+package docker
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	log "github.com/sirupsen/logrus"
+)
+
+// HasImage checks to see if a docker image exists locally.
+func HasImage(name string) (bool, error) {
+	args := filters.NewArgs()
+	args.Add("reference", name)
+
+	images, err := Client.ImageList(
+		context.Background(),
+		types.ImageListOptions{
+			Filters: args,
+		},
+	)
+
+	log.WithFields(log.Fields{
+		"image": name,
+		"count": len(images),
+	}).Debug("found image")
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(images) == 0 {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/ksync/background.go
+++ b/pkg/ksync/background.go
@@ -1,14 +1,11 @@
 package ksync
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	log "github.com/sirupsen/logrus"
 
-	"github.com/vapor-ware/ksync/pkg/docker"
 	"github.com/vapor-ware/ksync/pkg/service"
 )
 
@@ -31,8 +28,7 @@ func BackgroundWatch(cfgPath string, upgrade bool) error {
 		}
 	}
 
-	cntr, err := docker.Client.ContainerCreate(
-		context.Background(),
+	return service.Start(
 		&container.Config{
 			Cmd: []string{
 				"/ksync",
@@ -41,7 +37,7 @@ func BackgroundWatch(cfgPath string, upgrade bool) error {
 				"watch",
 			},
 			// TODO: make configurable
-			Image: "gcr.io/elated-embassy-152022/ksync/ksync:canary",
+			Image: imageName,
 			Labels: map[string]string{
 				"heritage": "ksync",
 			},
@@ -59,18 +55,4 @@ func BackgroundWatch(cfgPath string, upgrade bool) error {
 		},
 		&network.NetworkingConfig{},
 		"ksync-watch")
-
-	if err != nil {
-		return err
-	}
-
-	log.WithFields(log.Fields{
-		"id": cntr.ID,
-	}).Debug("container created")
-
-	if err := service.Start(&cntr); err != nil { // nolint: megacheck
-		return err
-	}
-
-	return nil
 }

--- a/pkg/ksync/radar_daemon_set.go
+++ b/pkg/ksync/radar_daemon_set.go
@@ -33,7 +33,7 @@ func (r *RadarInstance) daemonSet() *v1beta1.DaemonSet {
 						{
 							Name: r.name,
 							// TODO: configurable
-							Image:           "gcr.io/elated-embassy-152022/ksync/ksync:canary",
+							Image:           imageName,
 							ImagePullPolicy: "Always",
 							Command:         []string{"/radar", "--log-level=debug", "serve"},
 							Env: []v1.EnvVar{
@@ -60,7 +60,7 @@ func (r *RadarInstance) daemonSet() *v1beta1.DaemonSet {
 						{
 							Name: "mirror",
 							// TODO: configurable
-							Image:           "gcr.io/elated-embassy-152022/ksync/ksync:canary",
+							Image:           imageName,
 							ImagePullPolicy: "Always",
 							Command:         []string{"/bin/bash", "/mirror/mirror.sh", "server"},
 							Ports: []v1.ContainerPort{

--- a/pkg/ksync/radar_test.go
+++ b/pkg/ksync/radar_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	SetImage("gcr.io/elated-embassy-152022/ksync/ksync:canary")
+}
+
 func TestNewRadarInstance(t *testing.T) {
 	radar := NewRadarInstance()
 

--- a/pkg/ksync/service.go
+++ b/pkg/ksync/service.go
@@ -1,29 +1,34 @@
 package ksync
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
-	apiclient "github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/vapor-ware/ksync/pkg/debug"
-	"github.com/vapor-ware/ksync/pkg/docker"
 	"github.com/vapor-ware/ksync/pkg/service"
 )
+
+var (
+	imageName string
+)
+
+// SetImage sets the package-wide image to use for launching tasks
+// (both local and remote).
+func SetImage(name string) {
+	imageName = name
+}
 
 // Service reflects a sync that can be run in the background.
 type Service struct {
 	Name            string
 	RemoteContainer *RemoteContainer `structs:"-"`
 	Spec            *Spec            `structs:"-"`
-
-	image string // TODO: make this configurable
 }
 
 // NewService constructs a Service to manage and run local syncs from.
@@ -31,7 +36,6 @@ func NewService(name string, cntr *RemoteContainer, spec *Spec) *Service {
 	return &Service{
 		Name:            name,
 		RemoteContainer: cntr,
-		image:           "gcr.io/elated-embassy-152022/ksync/ksync:canary",
 		Spec:            spec,
 	}
 }
@@ -47,48 +51,6 @@ func (s *Service) Fields() log.Fields {
 
 func (s *Service) containerName() string {
 	return fmt.Sprintf("%s-%s", s.Name, s.RemoteContainer.PodName)
-}
-
-func (s *Service) create() (*container.ContainerCreateCreatedBody, error) {
-	cntr, err := docker.Client.ContainerCreate(
-		context.Background(),
-		&container.Config{
-			// TODO: make most of these options configurable.
-			// TODO: missing context
-			Cmd: []string{
-				"/ksync",
-				"--log-level=debug",
-				"run",
-				fmt.Sprintf("--pod=%s", s.RemoteContainer.PodName),
-				fmt.Sprintf("--container=%s", s.RemoteContainer.Name),
-				s.Spec.LocalPath,
-				s.Spec.RemotePath,
-			},
-			Image: s.image,
-			Labels: map[string]string{
-				"name":       s.Name,
-				"pod":        s.RemoteContainer.PodName,
-				"container":  s.RemoteContainer.Name,
-				"node":       s.RemoteContainer.NodeName,
-				"localPath":  s.Spec.LocalPath,
-				"remotePath": s.Spec.RemotePath,
-				"heritage":   "ksync",
-				"service":    "true",
-			},
-			User: s.Spec.User,
-		},
-		&container.HostConfig{
-			// TODO: need to make this configurable
-			Binds: []string{
-				fmt.Sprintf("%s:/.kube/config", s.Spec.KubeCfgPath),
-				fmt.Sprintf("%s:%s", s.Spec.LocalPath, s.Spec.LocalPath),
-			},
-			RestartPolicy: container.RestartPolicy{Name: "on-failure"},
-		},
-		&network.NetworkingConfig{},
-		s.containerName())
-
-	return &cntr, err
 }
 
 // Start runs a service in the background.
@@ -123,20 +85,42 @@ func (s *Service) Start() error {
 
 	// TODO: check whether the configured container user can write to localPath
 
-	cntr, err := s.create()
-	if err != nil {
-		if apiclient.IsErrImageNotFound(err) {
-			return fmt.Errorf("run `docker pull %s`", s.image)
-		}
-
-		return err
-	}
-
-	log.WithFields(MergeFields(s.Fields(), log.Fields{
-		"id": cntr.ID,
-	})).Debug("container created")
-
-	return service.Start(cntr)
+	return service.Start(
+		&container.Config{
+			// TODO: make most of these options configurable.
+			// TODO: missing context
+			Cmd: []string{
+				"/ksync",
+				"--log-level=debug",
+				"run",
+				fmt.Sprintf("--pod=%s", s.RemoteContainer.PodName),
+				fmt.Sprintf("--container=%s", s.RemoteContainer.Name),
+				s.Spec.LocalPath,
+				s.Spec.RemotePath,
+			},
+			Image: imageName,
+			Labels: map[string]string{
+				"name":       s.Name,
+				"pod":        s.RemoteContainer.PodName,
+				"container":  s.RemoteContainer.Name,
+				"node":       s.RemoteContainer.NodeName,
+				"localPath":  s.Spec.LocalPath,
+				"remotePath": s.Spec.RemotePath,
+				"heritage":   "ksync",
+				"service":    "true",
+			},
+			User: s.Spec.User,
+		},
+		&container.HostConfig{
+			// TODO: need to make this configurable
+			Binds: []string{
+				fmt.Sprintf("%s:/.kube/config", s.Spec.KubeCfgPath),
+				fmt.Sprintf("%s:%s", s.Spec.LocalPath, s.Spec.LocalPath),
+			},
+			RestartPolicy: container.RestartPolicy{Name: "on-failure"},
+		},
+		&network.NetworkingConfig{},
+		s.containerName())
 }
 
 // Stop halts a service that has been running in the background.

--- a/pkg/service/create.go
+++ b/pkg/service/create.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+
+	"github.com/vapor-ware/ksync/pkg/docker"
+)
+
+// Create builds a docker container after verifying that the image exists.
+func Create(
+	containerConfig *container.Config,
+	hostConfig *container.HostConfig,
+	networkConfig *network.NetworkingConfig,
+	containerName string) (*container.ContainerCreateCreatedBody, error) {
+
+	imageExists, err := docker.HasImage(containerConfig.Image)
+	if err != nil {
+		return nil, err
+	}
+
+	if !imageExists {
+		return nil, fmt.Errorf(
+			"%s does not exist, docker pull", containerConfig.Image)
+	}
+
+	cntr, err := docker.Client.ContainerCreate(
+		context.Background(),
+		containerConfig,
+		hostConfig,
+		networkConfig,
+		containerName)
+
+	return &cntr, err
+}

--- a/pkg/service/pull.go
+++ b/pkg/service/pull.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"os"
+	"os/exec"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Pull takes an image name and pulls it locally.
+func Pull(name string) error {
+	log.WithFields(log.Fields{
+		"image": name,
+	}).Debug("pulling image")
+
+	cmd := exec.Command("docker", "pull", name)
+
+	// TODO: make this configurable
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}

--- a/pkg/service/start.go
+++ b/pkg/service/start.go
@@ -5,21 +5,44 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/vapor-ware/ksync/pkg/docker"
 )
 
-// Start runs a container
-func Start(cntr *container.ContainerCreateCreatedBody) error {
+// Start takes container configuration and starts it locally.
+func Start(
+	containerConfig *container.Config,
+	hostConfig *container.HostConfig,
+	networkConfig *network.NetworkingConfig,
+	containerName string) error {
+
+	imageExists, err := docker.HasImage(containerConfig.Image)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !imageExists {
+		// Note: this won't work from inside the watch/run containers as there is no
+		// docker client and/or connection.
+		if pullErr := Pull(containerConfig.Image); pullErr != nil {
+			log.Fatal(pullErr)
+		}
+	}
+
+	cntr, err := Create(containerConfig, hostConfig, networkConfig, containerName)
+
+	if err != nil {
+		return err
+	}
+
 	if err := docker.Client.ContainerStart(
 		context.Background(),
 		cntr.ID,
 		types.ContainerStartOptions{}); err != nil {
 		return err
 	}
-
-	// TODO: make sure that the container comes up successfully.
 
 	log.WithFields(log.Fields{
 		"id": cntr.ID,


### PR DESCRIPTION
- Pulling images before they're required (so you don't get an error). Fixes #30
- Make the image name used (both local and remote) configurable. #12