### PR TITLE
Added ./ for it to able to resolve the path

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -3,7 +3,7 @@ You can also get the code and compile it yourself. If you have `go` installed yo
 ```shell
 go get github.com/ksync/ksync
 cd ${GOPATH}/src/github.com/ksync/ksync
-go install cmd/*
+go install ./cmd/*
 ```
 
 **Note**: If you compile the binaries yourself the output of `ksync version` may not be correct. Only the binaries on the [releases](https://github.com/ksync/ksync/releases) page are stamped with this information.


### PR DESCRIPTION
I was following this document to build locally

https://github.com/ksync/ksync/blob/master/docs/development.md

It was failing with this error.

```
$ env | grep GO
GOROOT=/usr/local/go
GOPATH=/Users/alok87/gocode
```

```
$ go install cmd/*
can't load package: package cmd/ksync: package cmd/ksync is not in GOROOT (/Users/alok87/src/cmd/ksync)
can't load package: package cmd/radar: package cmd/radar is not in GOROOT (/Users/alok87/src/cmd/radar)
```

Adding a `./` fixes it.

```
$ go install ./cmd/*
works !
```
